### PR TITLE
Install everything in one R session

### DIFF
--- a/R-3.2.3-cranatgh/Dockerfile
+++ b/R-3.2.3-cranatgh/Dockerfile
@@ -14,12 +14,13 @@ RUN apt-get update                     \
 
 ENV PATH /opt/R-3.2.3/bin:$PATH
 
-RUN echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"))'   \
-		>> ~/.Rprofile                                      \
-        && Rscript -e 'install.packages("devtools")'                \
-	&& Rscript -e 'devtools::install_github("gaborcsardi/gh")'  \
-	&& Rscript -e 'devtools::install_github("metacran/crandb")' \
-	&& Rscript -e 'devtools::install_github("metacran/description")' \
-	&& Rscript -e 'devtools::install_github("metacran/cranatgh")'
+RUN Rscript -e 'options(repos = c(CRAN = "https://cran.rstudio.com/"))' \
+            -e 'install.packages("devtools")'                           \
+            -e 'library(devtools)'                                      \
+            -e 'install_github("gaborcsardi/gh")'                       \
+            -e 'install_github("metacran/crandb")'                      \
+            -e 'install_github("metacran/description")'                 \
+            -e 'install_github("metacran/cranatgh")'
+
 
 USER jenkins


### PR DESCRIPTION
This installs all packages from one R session rather than using multiple. It should be slightly faster. I also explicitly attached devtools to avoid https://github.com/hadley/devtools/pull/936, the fix is not yet on CRAN.
